### PR TITLE
Add ioctl and __sincos_stret stubs

### DIFF
--- a/generate-stubs.py
+++ b/generate-stubs.py
@@ -41,6 +41,7 @@ def generateStubs(sysroot, outfile, target):
         # Exported by libSystem, but declared in headers that are not part of
         # this minimal SDK:
         '_ioctl',           # <sys/ioctl.h>
+        '___sincos_stret',  # newer <math.h>; called by LLVM-generated code
     }
 
     # Parse the src/libSystem.h file to get a list of functions declared in libSystem.

--- a/generate-stubs.py
+++ b/generate-stubs.py
@@ -38,6 +38,9 @@ def generateStubs(sysroot, outfile, target):
         '__tlv_bootstrap',
         '___memmove_chk', '___memset_chk',
         '___stack_chk_guard', '___stack_chk_fail',
+        # Exported by libSystem, but declared in headers that are not part of
+        # this minimal SDK:
+        '_ioctl',           # <sys/ioctl.h>
     }
 
     # Parse the src/libSystem.h file to get a list of functions declared in libSystem.

--- a/src/arm64/libSystem.s
+++ b/src/arm64/libSystem.s
@@ -1453,6 +1453,9 @@ _initgroups:
 .global _initstate
 _initstate:
 
+.global _ioctl
+_ioctl:
+
 .global _iruserok
 _iruserok:
 

--- a/src/arm64/libSystem.s
+++ b/src/arm64/libSystem.s
@@ -70,6 +70,9 @@ ___opendir2:
 .global ___sigbits
 ___sigbits:
 
+.global ___sincos_stret
+___sincos_stret:
+
 .global ___snprintf_chk
 ___snprintf_chk:
 

--- a/src/x86_64/libSystem.s
+++ b/src/x86_64/libSystem.s
@@ -70,6 +70,9 @@ ___opendir2$INODE64:
 .global ___sigbits
 ___sigbits:
 
+.global ___sincos_stret
+___sincos_stret:
+
 .global ___snprintf_chk
 ___snprintf_chk:
 

--- a/src/x86_64/libSystem.s
+++ b/src/x86_64/libSystem.s
@@ -1459,6 +1459,9 @@ _initgroups:
 .global _initstate
 _initstate:
 
+.global _ioctl
+_ioctl:
+
 .global _iruserok
 _iruserok:
 


### PR DESCRIPTION
Add two missing libSystem stub symbols, on both architectures:

- `_ioctl`
- `___sincos_stret`

Both are declared manually in `src/libSystem.h` (following the `__ulock_wait` precedent in 9b69407) because their real headers are not usable here, and both were verified against the macOS SDK `.tbd` export lists, which include them for x86_64 and arm64.

## `ioctl`

Exported by `libsystem_kernel.dylib` (re-exported by libSystem), but its real declaration lives in `<sys/ioctl.h>`, which is not part of this minimal SDK.

TinyGo wraps the variadic libc functions (`open`, `openat`, `fcntl`, `ioctl`) in fixed-signature C wrappers because darwin/arm64 passes variadic arguments on the stack while TinyGo's syscall engine calls imported addresses through fixed-signature function pointers. The `ioctl` wrapper references `_ioctl`, and without this stub every darwin link of such a binary fails with `linker could not find symbol _ioctl`. This came up while fixing tinygo-org/tinygo#5365 (x/sys `//go:cgo_import_dynamic` trampolines on darwin); the TinyGo compiler PR that depends on this stub is forthcoming.

## `__sincos_stret`

LLVM emits calls to `__sincos_stret` for complex sin/cos on darwin (TinyGo hits this when compiling Go complex math). It is exported by `libmathCommon.dylib` (re-exported by libSystem), but its declaration only exists in newer `<math.h>` versions than the one vendored here, hidden behind a deployment-target guard.

Only the `double` variant is added since that's the symbol observed missing; `__sincosf_stret` / `__sincospi_stret` / `__sincospif_stret` can be added the same way if ever needed.

## Testing

`make test` (with clang 22) builds both sysroots and links the hello-world test for x86_64 and arm64. The new stubs were also verified end-to-end with a TinyGo build of a `golang.org/x/sys/unix` program that previously failed to link.
